### PR TITLE
Special case of exact approximation in check functions

### DIFF
--- a/manopt/tools/checkdiff.m
+++ b/manopt/tools/checkdiff.m
@@ -101,20 +101,39 @@ function checkdiff(problem, x, d, force_gradient)
          'color', 'k', 'LineStyle', '--', ...
          'YLimInclude', 'off', 'XLimInclude', 'off');
     
-    
-    % In a numerically reasonable neighborhood, the error should decrease
-    % as the square of the stepsize, i.e., in loglog scale, the error
-    % should have a slope of 2.
-    window_len = 10;
-    [range, poly] = identify_linear_piece(log10(h), log10(err), window_len);
+     
+    if all( err < 1e-12 ) % threshold for numerical errors
+        % The 1st order model is exact: all errors are (numerically) zero
+        % Fit line from all points, use log scale only in h
+        isModelExact = true;
+        range = 1:numel(h);
+        poly = polyfit(log10(h), err, 1);
+        poly(end) = log10(poly(end)); % Set mean error in log scale for plot
+        % Change title to something more descriptive for the special case at hand
+        title(sprintf(...
+              ['Directional derivative check.\n'...
+               'It seems the linear model is exact:\n'...
+               'Model error is numerically zero for all h.']));
+    else
+        % In a numerically reasonable neighborhood, the error should decrease
+        % as the square of the stepsize, i.e., in loglog scale, the error
+        % should have a slope of 2.
+        isModelExact = false;
+        window_len = 10;
+        [range, poly] = identify_linear_piece(log10(h), log10(err), window_len);
+    end
     hold all;
     loglog(h(range), 10.^polyval(poly, log10(h(range))), 'LineWidth', 3);
     hold off;
     
+    if ~exist('isModelExact','var') || ~isModelExact
     fprintf('The slope should be 2. It appears to be: %g.\n', poly(1));
     fprintf(['If it is far from 2, then directional derivatives ' ...
              'might be erroneous.\n']);
-    fprintf(['If it is very close to 0, then the modeled funtion is '...
-             'probably linear and the approximate model is exact.\n']);
+    else
+    fprintf(['The linear model appears to be exact ' ...
+             '(within numerical precision), '...
+             'so the slope computation is irrelevant.\n']);
+    end
     
 end

--- a/manopt/tools/checkdiff.m
+++ b/manopt/tools/checkdiff.m
@@ -126,7 +126,7 @@ function checkdiff(problem, x, d, force_gradient)
     loglog(h(range), 10.^polyval(poly, log10(h(range))), 'LineWidth', 3);
     hold off;
     
-    if ~exist('isModelExact','var') || ~isModelExact
+    if ~isModelExact
     fprintf('The slope should be 2. It appears to be: %g.\n', poly(1));
     fprintf(['If it is far from 2, then directional derivatives ' ...
              'might be erroneous.\n']);

--- a/manopt/tools/checkdiff.m
+++ b/manopt/tools/checkdiff.m
@@ -114,5 +114,7 @@ function checkdiff(problem, x, d, force_gradient)
     fprintf('The slope should be 2. It appears to be: %g.\n', poly(1));
     fprintf(['If it is far from 2, then directional derivatives ' ...
              'might be erroneous.\n']);
+    fprintf(['If it is very close to 0, then the modeled funtion is '...
+             'probably linear and the approximate model is exact.\n']);
     
 end

--- a/manopt/tools/checkdiff.m
+++ b/manopt/tools/checkdiff.m
@@ -23,6 +23,10 @@ function checkdiff(problem, x, d, force_gradient)
 % Contributors: 
 % Change log: 
 %
+%   March 26, 2017 (JB):
+%       Detects if the approximated linear model is exact
+%       and provides the user with the corresponding feedback.
+% 
 %   April 3, 2015 (NB):
 %       Works with the new StoreDB class system.
 

--- a/manopt/tools/checkhessian.m
+++ b/manopt/tools/checkhessian.m
@@ -126,7 +126,7 @@ function checkhessian(problem, x, d)
         loglog(h(range), 10.^polyval(poly, log10(h(range))), 'LineWidth', 3);
     hold off;
     
-    if ~exist('isModelExact','var') || ~isModelExact
+    if ~isModelExact
     fprintf('The slope should be 3. It appears to be: %g.\n', poly(1));
     fprintf(['If it is far from 3, then directional derivatives or ' ...
              'the Hessian might be erroneous.\n']);

--- a/manopt/tools/checkhessian.m
+++ b/manopt/tools/checkhessian.m
@@ -24,6 +24,10 @@ function checkhessian(problem, x, d)
 % Contributors: 
 % Change log: 
 %
+%   March 26, 2017 (JB):
+%       Detects if the approximated quadratic model is exact
+%       and provides the user with the corresponding feedback.
+% 
 %   April 3, 2015 (NB):
 %       Works with the new StoreDB class system.
 %

--- a/manopt/tools/checkhessian.m
+++ b/manopt/tools/checkhessian.m
@@ -100,37 +100,47 @@ function checkhessian(problem, x, d)
          'color', 'k', 'LineStyle', '--', ...
          'YLimInclude', 'off', 'XLimInclude', 'off');
     
-    if all( err < 1e-10 ) % hard-coded threshold for now
-      % The 2nd order model is exact: error is zero everywhere
-      % Fit line from all points, use log scale only in h
-      range = 1:numel(h);
-      poly = polyfit(log10(h), err, 1);
-      poly(end) = log10(poly(end)); % Set mean error in log scale for plot
-      warning('The model seems exact! Error is zero (near numerical precision) everywhere')
+    
+    if all( err < 1e-12 ) % threshold for numerical errors
+        % The 2nd order model is exact: all errors are (numerically) zero
+        % Fit line from all points, use log scale only in h
+        isModelExact = true;
+        range = 1:numel(h);
+        poly = polyfit(log10(h), err, 1);
+        poly(end) = log10(poly(end)); % Set mean error in log scale for plot
+        % Change title to something more descriptive for the special case at hand
+        title(sprintf(...
+              ['Hessian check.\n'...
+               'It seems the quadratic model is exact:\n'...
+               'Model error is numerically zero for all h.']));
     else
-      % In a numerically reasonable neighborhood, the error should decrease
-      % as the cube of the stepsize, i.e., in loglog scale, the error
-      % should have a slope of 3.
-      % Find neighborhood for interp of trend
-      window_len = 10;
-      [range, poly] = identify_linear_piece(log10(h), log10(err), window_len);
+        % In a numerically reasonable neighborhood, the error should decrease
+        % as the cube of the stepsize, i.e., in loglog scale, the error
+        % should have a slope of 3.
+        % Find neighborhood for interp of trend
+        isModelExact = false;
+        window_len = 10;
+        [range, poly] = identify_linear_piece(log10(h), log10(err), window_len);
     end
     hold all;
-        loglog(h(range), 10.^polyval(poly, log10(h(range))), ...
-               'r-', 'LineWidth', 3);
+        loglog(h(range), 10.^polyval(poly, log10(h(range))), 'LineWidth', 3);
     hold off;
     
+    if ~exist('isModelExact','var') || ~isModelExact
     fprintf('The slope should be 3. It appears to be: %g.\n', poly(1));
     fprintf(['If it is far from 3, then directional derivatives or ' ...
              'the Hessian might be erroneous.\n']);
-    fprintf(['If it is very close to 0, then the modeled funtion is '...
-             'probably quadratic and the approximate model is exact.\n']);
     fprintf(['Note: if the exponential map is only approximate, and it '...
              'is not a second-order approximation,\nthen it is normal ' ...
              'for the slope test to reach 2 instead of 3. Check the ' ...
              'factory for this.\n' ...
              'If tested at a critical point, then even for a first-order '...
              'retraction the slope test should yield 3.\n']);
+    else
+    fprintf(['The quadratic model appears to be exact ' ...
+             '(within numerical precision), '...
+             'so the slope computation is irrelevant.\n']);
+    end
 
     
     %% Check that the Hessian at x along direction d is a tangent vector.

--- a/tests/Test_linearFunction.m
+++ b/tests/Test_linearFunction.m
@@ -1,0 +1,38 @@
+function Test_linearFunction
+
+% Define a linear space
+m = 5;
+n = 2;
+manifold = euclideanfactory(m,n);
+
+% random symmetric square matrix
+A = randn(m,n);
+
+% Create the problem structure.
+problem.M = manifold;
+
+% Define the problem cost function, Euclidean gradient and Hessian.
+problem.cost = @cost;
+function f = cost(X)
+  f = trace(A'*X);
+end
+
+problem.egrad = @egrad;
+function G = egrad(X)
+  G = A;
+end
+
+problem.ehess = @ehess;
+function H = ehess(X, Xdot)
+  H = zeros(size(Xdot));
+end
+
+% Check gradient and Hessian correctness
+% This is a quadratic function in a linear manifold,
+% so the quadratic approximation used in `checkhessian` should be exact
+% Other similar cases are those where the unknowns belong to a tangent
+% space (also a linear manifold).
+checkgradient( problem ); pause
+checkhessian(  problem ); pause
+
+end

--- a/tests/Test_quadraticFunction.m
+++ b/tests/Test_quadraticFunction.m
@@ -1,0 +1,38 @@
+function Test_quadraticFunction
+
+% Define a linear space
+m = 5;
+n = 2;
+manifold = euclideanfactory(m,n);
+
+% random symmetric square matrix
+Q = multisym(randn(m));
+
+% Create the problem structure.
+problem.M = manifold;
+
+% Define the problem cost function, Euclidean gradient and Hessian.
+problem.cost = @cost;
+function f = cost(X)
+  f = 0.5*trace(X'*Q*X);
+end
+
+problem.egrad = @egrad;
+function G = egrad(X)
+  G = Q*X;
+end
+
+problem.ehess = @ehess;
+function H = ehess(X, Xdot)
+  H = Q*Xdot;
+end
+
+% Check gradient and Hessian correctness
+% This is a quadratic function in a linear manifold,
+% so the quadratic approximation used in `checkhessian` should be exact
+% Other similar cases are those where the unknowns belong to a tangent
+% space (also a linear manifold).
+checkgradient( problem ); pause
+checkhessian(  problem ); pause
+
+end


### PR DESCRIPTION
Added some comments and control for the special case
when the Taylor expansion is exact.
This may arise when using linear manifolds, such as `tangentspacefactory` or `normalspacefactory`
More comments in the Manopt thread:
https://groups.google.com/forum/#!topic/manopttoolbox/ls2EmvkaHjQ