### PR TITLE
Added (optional) field veclen: Useful for productmanifold

### DIFF
--- a/manopt/manifolds/euclidean/euclideanfactory.m
+++ b/manopt/manifolds/euclidean/euclideanfactory.m
@@ -96,6 +96,7 @@ function M = euclideanfactory(m, n)
     M.pairmean = @(x1, x2) .5*(x1+x2);
     
     M.vec = @(x, u_mat) u_mat(:);
+    M.veclen = M.dim(); % a constant value
     M.mat = @(x, u_vec) reshape(u_vec, dimensions_vec);
     M.vecmatareisometries = @() true;
 

--- a/manopt/manifolds/stiefel/stiefelstackedfactory.m
+++ b/manopt/manifolds/stiefel/stiefelstackedfactory.m
@@ -166,6 +166,7 @@ function M = stiefelstackedfactory(m, d, k)
     M.transp = @(x1, x2, u) projection(x2, u);
     
     M.vec = @(x, u_mat) u_mat(:);
+    M.veclen = m*d*k;
     M.mat = @(x, u_vec) reshape(u_vec, [n, k]);
     M.vecmatareisometries = @() true;
 

--- a/manopt/tools/productmanifold.m
+++ b/manopt/tools/productmanifold.m
@@ -235,7 +235,9 @@ function M = productmanifold(elements)
     vec_lens = zeros(nelems, 1);
     for ii = 1 : nelems
         Mi = elements.(elems{ii});
-        if isfield(Mi, 'vec')
+        if isfield(Mi, 'veclen')
+            vec_lens(ii) = Mi.veclen;
+        elseif isfield(Mi, 'vec')
             rand_x = Mi.rand();
             zero_u = Mi.zerovec(rand_x);
             vec_lens(ii) = length(Mi.vec(rand_x, zero_u));


### PR DESCRIPTION
productmanifold requires to know the length of the vec output
for each element manifold. Currently, this length is computed
by measuring the length of a zero vector at a random point.
This however requires the generation of a random point in the manifold,
which can in some cases produce an unnecessary overhead.

The new (optional) field veclen should provide the size of the output
for vec in a particular manifold.
For now, this has been set for euclideanfactory and stiefelstackedfactory.