### PR TITLE
exp, log and dist for multinomial matrices

### DIFF
--- a/manopt/manifolds/multinomial/multinomialfactory.m
+++ b/manopt/manifolds/multinomial/multinomialfactory.m
@@ -24,6 +24,13 @@ function M = multinomialfactory(n, m)
 %
 % Link to the paper: http://arxiv.org/abs/1504.01777.
 %
+% The exponential and logarithmic map and the distance are taken from
+% F. Åström, S. Petra, B. Schmitzer, C. Schnörr, ?Image Labeling by
+% Assignment?, Journal of Mathematical Imaging and Vision, 58(2),
+% pp. 221?238, 2017.
+% doi: https://doi.org/10.1007/s10851-016-0702-4
+% arxiv: https://arxiv.org/abs/1603.05285
+%
 % Please cite the Manopt paper as well as the research paper:
 % @Article{sun2015multinomial,
 %   author  = {Y. Sun and J. Gao and X. Hong and B. Mishra and B. Yin},
@@ -43,6 +50,9 @@ function M = multinomialfactory(n, m)
 %
 %    Sep. 6, 2018 (NB):
 %        Removed M.exp() as it was not implemented.
+%
+%    Apr. 12, 2020 (RB):
+%        Adds exp, log, dist.
 
     if ~exist('m', 'var') || isempty(m)
         m = 1;
@@ -67,6 +77,34 @@ function M = multinomialfactory(n, m)
     % Column vector of ones of length n.
     % TODO: eliminate e by using bsxfun
     e = ones(n, 1);
+    
+    M.exp = @exponential;
+    function Y = exponential(X, U, t)
+        if nargin == 3
+            tU = t*U;
+        else
+            tU = U;
+        end
+        Y = zeros(size(X));
+        for mm = 1 : m
+            x = X(:,mm);
+            s = sqrt(x);
+            us = U(:,mm) ./ s ./ 2;
+            un = norm(us);
+            if un < eps
+                Y(:,mm) = X(:,mm);
+            else
+                Y(:,mm) = (cos(un).*s +  sin(un)/un.*us).^2;
+            end
+        end
+    end
+
+    M.log = @logarithm;
+    function U = logarithm(X,Y)
+        a = sqrt(X.*Y);
+        s = sum(a,1);
+        U = 2*acos(s) ./ sqrt(1-s.^2) .* ( a - s.*X);
+    end
     
     M.egrad2rgrad = @egrad2rgrad;
     function rgrad = egrad2rgrad(X, egrad)

--- a/manopt/manifolds/multinomial/multinomialfactory.m
+++ b/manopt/manifolds/multinomial/multinomialfactory.m
@@ -60,7 +60,7 @@ function M = multinomialfactory(n, m)
     
     M.norm = @(X, eta) sqrt(M.inner(X, eta, eta));
     
-    M.dist = @(X, Y) error('multinomialfactory.dist not implemented yet.');
+    M.dist = @(X, Y) norm( 2*acos(sum(sqrt(X.*Y),1)) );
     
     M.typicaldist = @() m*pi/2; % This is an approximation.
     

--- a/manopt/manifolds/multinomial/multinomialfactory.m
+++ b/manopt/manifolds/multinomial/multinomialfactory.m
@@ -24,11 +24,11 @@ function M = multinomialfactory(n, m)
 %
 % Link to the paper: http://arxiv.org/abs/1504.01777.
 %
-% The exponential and logarithmic map and the distance are taken from
-% F. Åström, S. Petra, B. Schmitzer, C. Schnörr, ?Image Labeling by
-% Assignment?, Journal of Mathematical Imaging and Vision, 58(2),
-% pp. 221?238, 2017.
-% doi: https://doi.org/10.1007/s10851-016-0702-4
+% The exponential and logarithmic map and the distance appear in:
+% F. Astrom, S. Petra, B. Schmitzer, C. Schnorr,
+% "Image Labeling by Assignment",
+% Journal of Mathematical Imaging and Vision, 58(2), pp. 221?238, 2017.
+% doi: 10.1007/s10851-016-0702-4
 % arxiv: https://arxiv.org/abs/1603.05285
 %
 % Please cite the Manopt paper as well as the research paper:
@@ -45,7 +45,7 @@ function M = multinomialfactory(n, m)
 
 % This file is part of Manopt: www.manopt.org.
 % Original author: Bamdev Mishra, April 06, 2015.
-% Contributors:
+% Contributors: Ronny Bergmann
 % Change log:
 %
 %    Sep. 6, 2018 (NB):
@@ -70,7 +70,7 @@ function M = multinomialfactory(n, m)
     
     M.norm = @(X, eta) sqrt(M.inner(X, eta, eta));
     
-    M.dist = @(X, Y) norm( 2*acos(sum(sqrt(X.*Y),1)) );
+    M.dist = @(X, Y) norm(2*acos(sum(sqrt(X.*Y), 1)));
     
     M.typicaldist = @() m*pi/2; % This is an approximation.
     
@@ -87,14 +87,14 @@ function M = multinomialfactory(n, m)
         end
         Y = zeros(size(X));
         for mm = 1 : m
-            x = X(:,mm);
+            x = X(:, mm);
             s = sqrt(x);
-            us = U(:,mm) ./ s ./ 2;
+            us = U(:, mm) ./ s ./ 2;
             un = norm(us);
             if un < eps
-                Y(:,mm) = X(:,mm);
+                Y(:, mm) = X(:, mm);
             else
-                Y(:,mm) = (cos(un).*s +  sin(un)/un.*us).^2;
+                Y(:, mm) = (cos(un).*s + sin(un)/un.*us).^2;
             end
         end
     end
@@ -102,8 +102,8 @@ function M = multinomialfactory(n, m)
     M.log = @logarithm;
     function U = logarithm(X,Y)
         a = sqrt(X.*Y);
-        s = sum(a,1);
-        U = 2*acos(s) ./ sqrt(1-s.^2) .* ( a - s.*X);
+        s = sum(a, 1);
+        U = 2*acos(s) ./ sqrt(1-s.^2) .* (a - s.*X);
     end
     
     M.egrad2rgrad = @egrad2rgrad;


### PR DESCRIPTION
I was recently working on an implementation in Julia (https://juliamanifolds.github.io/Manifolds.jl/stable/manifolds/probabilitysimplex.html for the single case, matrices are then https://juliamanifolds.github.io/Manifolds.jl/stable/manifolds/multinomial.html).

I noticed, that the implementation here misses exp, log and dist. Since it is not that much to convert my code also to Matlab; this PR is my code. 

I also wrote a small test, but I am not sure where to place it, it's
````matlab
M = multinomialfactory(3);
X = [0.1 0.7 0.2]';
Y = [0.3 0.6 0.1]';
M.dist(X,Y) % ≈ 0.5479686334735132
U = M.log(X,Y) % ≈ [0.1558, -0.0523, -0.1035]'
Z = M.exp(X,U) % ≈ Y

M2 = multinomialfactory(3,2);
X2 = [0.1 0.3; 0.7 0.6; 0.2 0.1];
Y2 = [0.3 0.1; 0.6 0.7; 0.1 0.2];
M2.dist(X2,Y2) % ≈ 0.7749 (or sqrt(2) times the distance above)
U2 = M2.log(X2,Y2) % ≈ [0.1558 -0.2341; -0.0523 0.1427; -0.1035 0.0914]
Z2 = M2.exp(X2,U2) % ≈ Y2
````

I also tried to provide the reference and already check the log.