### PR TITLE
Update rule for e_Pd

### DIFF
--- a/auxiliaries/CREDITS.txt
+++ b/auxiliaries/CREDITS.txt
@@ -38,6 +38,7 @@ We are grateful for the excellent contributions of
 * Nick Vannieuwenhoven
 * Spencer Kraisler
 * sfrcorne (github handle)
+* Bonan Sun
 
 Furthermore, code written by the following people can be found in Manopt:
 

--- a/manopt/solvers/trustregions/trs_tCG.m
+++ b/manopt/solvers/trustregions/trs_tCG.m
@@ -329,7 +329,8 @@ for j = 1 : options.maxinner
     % No negative curvature and eta_prop inside TR: accept it.
     e_Pe = e_Pe_new;
     new_eta  = lincomb(1,  eta, -alpha,  mdelta);
-    
+    disp([e_Pe,inner(new_eta,new_eta)])
+    disp(abs(e_Pe-inner(new_eta,new_eta)))
     % If only a nonlinear Hessian approximation is available, this is
     % only approximately correct, but saves an additional Hessian call.
     % TODO: this computation is redundant with that of r, L241. Clean up.
@@ -397,9 +398,17 @@ for j = 1 : options.maxinner
     % being that loss of tangency can lead to more inner iterations being
     % run, which leads to an overall higher computational cost.
     mdelta = tangent(mdelta);
-    
+    %disp(M.norm(x,lincomb(1,lincomb(1,Heta,1,grad),-1,r)))
     % Update new P-norms and P-dots [CGT2000, eq. 7.5.6 & 7.5.7].
-    e_Pd = beta*(e_Pd + alpha*d_Pd);
+    if ~options.useRand
+        e_Pd = beta*(e_Pd + alpha*d_Pd);
+    else
+        % When eta0 is not zero, then the update rule above is not valid
+        % mathematically. But since we take eta0 small, it is still 
+        % approximately true numerically. Using the exact values might
+        % increase numerical stability.
+        e_Pd = -inner(eta,mdelta);
+    end
     d_Pd = z_r + beta*beta*d_Pd;
     
 end  % of tCG loop

--- a/manopt/solvers/trustregions/trs_tCG.m
+++ b/manopt/solvers/trustregions/trs_tCG.m
@@ -329,8 +329,7 @@ for j = 1 : options.maxinner
     % No negative curvature and eta_prop inside TR: accept it.
     e_Pe = e_Pe_new;
     new_eta  = lincomb(1,  eta, -alpha,  mdelta);
-    disp([e_Pe,inner(new_eta,new_eta)])
-    disp(abs(e_Pe-inner(new_eta,new_eta)))
+    
     % If only a nonlinear Hessian approximation is available, this is
     % only approximately correct, but saves an additional Hessian call.
     % TODO: this computation is redundant with that of r, L241. Clean up.
@@ -398,7 +397,7 @@ for j = 1 : options.maxinner
     % being that loss of tangency can lead to more inner iterations being
     % run, which leads to an overall higher computational cost.
     mdelta = tangent(mdelta);
-    %disp(M.norm(x,lincomb(1,lincomb(1,Heta,1,grad),-1,r)))
+    
     % Update new P-norms and P-dots [CGT2000, eq. 7.5.6 & 7.5.7].
     if ~options.useRand
         e_Pd = beta*(e_Pd + alpha*d_Pd);


### PR DESCRIPTION
When eta0 is not zero, then the update rule [CGT2000, eq. 7.5.6] is not valid mathematically. But since we take eta0 small, it is still approximately (numerically) true. Using the exact values might increase numerical stability. 