### PR TITLE
Add beta_type rules from Sato's paper

### DIFF
--- a/manopt/solvers/conjugategradient/conjugategradient.m
+++ b/manopt/solvers/conjugategradient/conjugategradient.m
@@ -50,6 +50,8 @@ function [x, cost, info, options] = conjugategradient(problem, x, options)
 %           'H-S' for Hestenes-Stiefel's modified rule
 %           'H-Z' for Hager-Zhang's modified rule
 %           'L-S' for Sato's Liu-Storey rule
+%           'P-R-SATO' for Sato's variation of modified PR rule
+%           'H-S-SATO' for Sato's variation of modified HS rule
 %       See Hager and Zhang 2006, "A survey of nonlinear conjugate gradient
 %       methods" for a description of these rules in the Euclidean case and
 %       for an explanation of how to adapt them to the preconditioned case.
@@ -113,7 +115,7 @@ function [x, cost, info, options] = conjugategradient(problem, x, options)
 
 % This file is part of Manopt: www.manopt.org.
 % Original author: Bamdev Mishra, Dec. 30, 2012.
-% Contributors: Nicolas Boumal, Nick Vannieuwenhoven
+% Contributors: Nicolas Boumal, Nick Vannieuwenhoven, Ivan Bioli
 % Change log: 
 %
 %   March 14, 2013, NB:
@@ -146,6 +148,9 @@ function [x, cost, info, options] = conjugategradient(problem, x, options)
 %
 %   Feb. 7, 2022 (NV):
 %       Added support for Liu-Storey rule (L-S).
+%
+%   Nov. 7, 2023 (IB):
+%       Fixed Liu-Storey rule (L-S) + added H-S-SATO and P-R-SATO.
 
 M = problem.M;
 
@@ -367,14 +372,6 @@ while true
                     beta = max(beta, eta_HZ);
                 
                 case 'L-S' % Liu-Storey+ from Sato
-                    diff = M.lincomb(newx, 1, newgrad, -1, oldgrad);
-                    ip_diff = M.inner(newx, Pnewgrad, diff);
-                    denom = -1*M.inner(x, grad, desc_dir); %NOTE: desc_dir is in the tangent space of newx
-                    betaLS = ip_diff / denom;
-                    betaCD = newgradPnewgrad / denom;
-                    beta = max(0, min(betaLS, betaCD));
-
-                case 'L-S-SATO' % Liu-Storey+ from Sato's paper
                     Poldgrad = M.transp(x, newx, Pgrad);
                     numo = newgradPnewgrad - M.inner(newx, newgrad, Poldgrad);
                     deno = -1*M.inner(x, grad, old_desc_dir);
@@ -384,7 +381,8 @@ while true
 
                 otherwise
                     error(['Unknown options.beta_type. ' ...
-                           'Should be steep, S-D, F-R, P-R, H-S, H-Z, or L-S.']);
+                           'Should be steep, S-D, F-R, P-R, H-S, H-Z, ' ...
+                           'L-S, P-R-SATO or H-S-SATO.']);
             end
             
             desc_dir = M.lincomb(newx, -1, Pnewgrad, beta, desc_dir);


### PR DESCRIPTION
I modified the rules for $\beta_k$ in the `conjugategradient` solver according to [Sato's paper](https://doi.org/10.1137/21M1464178).  The formulas come from equations (4.10)-(4.12) and section 6.2, and can be easily adapted to the preconditioned case (interpreting the preconditioner as a change of metric). 

In practice, on the particular problem I am working on, the performace is essentially the same. The only exception is the current Manopt's version of the `'L-S'` rule, which works worse than the others. I believe the problem comes from `desc_dir` being a vector in the tangent space of `newx` (not `x`).

Still, the new rules have the property that that the preconditioner acts effectively like a change of metric, which was not enforced with the current version of $\beta_k$, as pointed out by @NicolasBoumal [in this question on the forum](https://groups.google.com/g/manopttoolbox/c/KeEcRLnmFek).

NOTE: If you want to compare the different rules for a benchmark problem you have, you can use the following simple code
```
x0 = problem_pcg.M.rand();
betas = ["P-R", "H-S", "L-S", "P-R-SATO", "H-S-SATO", "L-S-SATO"];
for i = 1:length(betas)
    beta_type = betas(i);
    opts_cg.beta_type = beta_type;
    [~, ~, info, ~] = conjugategradient(problem_pcg, x0, opts_cg);
    results{i} = info;
    names{i} = beta_type;
end

figure();
for i = 1:length(betas)
    info = results{i};
    name = names{i};
    semilogy([info.iter], [info.gradnorm], 'DisplayName', name);
    hold on
end
legend()
```