### PR TITLE
Propose an inverse retraction check

### DIFF
--- a/manopt/tools/checkinverseretraction.m
+++ b/manopt/tools/checkinverseretraction.m
@@ -83,7 +83,7 @@ function checkinverseretraction(M, x, v)
     
     fprintf('Check agreement between M.log and M.invretr. Please check the\n');
     fprintf('factory file of M to ensure M.log is a proper logarithm.\n');
-    fprintf('The slope must be at least 2 to have a proper invese retraction.\n');
+    fprintf('The slope must be at least 2 to have a proper inverse retraction.\n');
     fprintf('For the inverse retraction to be second order, the slope should be 3.\n');
     fprintf('It appears the slope is: %g.\n', poly(1));
     fprintf(['Note: If M.log and M.invretr are identical, ' ...

--- a/manopt/tools/checkinverseretraction.m
+++ b/manopt/tools/checkinverseretraction.m
@@ -1,16 +1,16 @@
 function checkinverseretraction(M, x, v)
-% Check the order of agreement of a retraction with an exponential.
+% Check the order of agreement of an inverse retraction with the log.
 % 
 % function checkinverseretraction(M)
 % function checkinverseretraction(M, x)
 % function checkinverseretraction(M, x, v)
 %
-% checkinverseretraction performs a numerical test to check the order of agreement
-% between the inverse retraction M.invretr and the logarithmic map M.log in a
-% given Manopt manifold structure M. The test is performed at the point x if it is
-% provided (otherwise, the point is picked at random) and along the tangent
-% vector v at x if one is provided (otherwise, a tangent vector at x is
-% picked at random.)
+% checkinverseretraction performs a numerical test to check the order of
+% agreement between the inverse retraction and the logarithmic map in a
+% given Manopt manifold structure M. The test is performed at the point x
+% if it is provided (otherwise, the point is picked at random) and along
+% the tangent vector v at x if one is provided (otherwise, a tangent vector
+% at x is picked at random.)
 %
 % See also: checkretraction checkmanifold checkdiff checkgradient checkhessian
 

--- a/manopt/tools/checkinverseretraction.m
+++ b/manopt/tools/checkinverseretraction.m
@@ -1,30 +1,34 @@
-function checkretraction(M, x, v)
+function checkinverseretraction(M, x, v)
 % Check the order of agreement of a retraction with an exponential.
 % 
-% function checkretraction(M)
-% function checkretraction(M, x)
-% function checkretraction(M, x, v)
+% function checkinverseretraction(M)
+% function checkinverseretraction(M, x)
+% function checkinverseretraction(M, x, v)
 %
-% checkretraction performs a numerical test to check the order of agreement
-% between the retraction and the exponential map in a given Manopt
+% checkinverseretraction performs a numerical test to check the order of agreement
+% between the inverse retraction and the logarithmic map in a given Manopt
 % manifold structure M. The test is performed at the point x if it is
 % provided (otherwise, the point is picked at random) and along the tangent
 % vector v at x if one is provided (otherwise, a tangent vector at x is
 % picked at random.)
 %
-% See also: checkinverseretraction checkmanifold checkdiff checkgradient checkhessian
+% See also: checkretraction checkmanifold checkdiff checkgradient checkhessian
 
 % This file is part of Manopt: www.manopt.org.
-% Original author: Nicolas Boumal, Oct. 21, 2016.
+% Original author: Ronny Bergmann, May 3rd, 2024.
 % Contributors: 
 % Change log: 
 
     if ~isfield(M, 'exp')
-        error(['This manifold has no exponential (M.exp): ' ...
-               'no reference to compare the retraction.']);
+        error(['This manifold has no exponential (M.exp) ' ...
+               'which is required to generate points of certain distance to x.']);
     end
-    if ~isfield(M, 'dist')
-        error(['This manifold has no distance (M.dist): ' ...
+    if ~isfield(M, 'log')
+        error(['This manifold has no logarithmic (M.exp): ' ...
+               'no reference to compare the inverse retraction.']);
+    end
+    if ~isfield(M, 'norm')
+        error(['This manifold has no norm (M.nrom): ' ...
                'this is required to run this check.']);
     end
 
@@ -43,7 +47,8 @@ function checkretraction(M, x, v)
     ee = zeros(size(tt));
     for k = 1 : numel(tt)
         t = tt(k);
-        ee(k) = M.dist(M.exp(x, v, t), M.retr(x, v, t));
+        y = M.exp(M, v, t);
+        ee(k) = M.norm(M.log(x, y), M.invretr(x, y));
     end
     
     % Plot the difference between the exponential and the retration over
@@ -72,15 +77,14 @@ function checkretraction(M, x, v)
     hold off;
     
     xlabel('Step size multiplier t');
-    ylabel('Distance between Exp(x, v, t) and Retr(x, v, t)');
-    title(sprintf('Retraction check.\nA slope of 2 is required, 3 is desired.'));
+    ylabel('Distance between Log(x, y) and InvRetr(x, y) for y = Exp(x, v, t)');
+    title(sprintf('Inverse Retraction check.\nA slope of 2 is required, 3 is desired.'));
     
-    fprintf('Check agreement between M.exp and M.retr. Please check the\n');
-    fprintf('factory file of M to ensure M.exp is a proper exponential.\n');
-    fprintf('The slope must be at least 2 to have a proper retraction.\n');
-    fprintf('For the retraction to be second order, the slope should be 3.\n');
+    fprintf('Check agreement between M.log and M.invretr. Please check the\n');
+    fprintf('factory file of M to ensure M.log is a proper logarithm.\n');
+    fprintf('The slope must be at least 2 to have a proper invese retraction.\n');
+    fprintf('For the inverse retraction to be second order, the slope should be 3.\n');
     fprintf('It appears the slope is: %g.\n', poly(1));
     fprintf('Note: if exp and retr are identical, this is about zero: %g.\n', norm(ee));
     fprintf('In the latter case, the slope test is irrelevant.\n');
-
 end

--- a/manopt/tools/checkinverseretraction.m
+++ b/manopt/tools/checkinverseretraction.m
@@ -47,7 +47,7 @@ function checkinverseretraction(M, x, v)
     ee = zeros(size(tt));
     for k = 1 : numel(tt)
         t = tt(k);
-        y = M.exp(M, v, t);
+        y = M.exp(x, v, t);
         diff = M.lincomb(x, 1, M.log(x, y), -1, M.invretr(x, y));
         ee(k) = M.norm(x, diff);
     end

--- a/manopt/tools/checkinverseretraction.m
+++ b/manopt/tools/checkinverseretraction.m
@@ -6,8 +6,8 @@ function checkinverseretraction(M, x, v)
 % function checkinverseretraction(M, x, v)
 %
 % checkinverseretraction performs a numerical test to check the order of agreement
-% between the inverse retraction and the logarithmic map in a given Manopt
-% manifold structure M. The test is performed at the point x if it is
+% between the inverse retraction M.invretr and the logarithmic map M.log in a
+% given Manopt manifold structure M. The test is performed at the point x if it is
 % provided (otherwise, the point is picked at random) and along the tangent
 % vector v at x if one is provided (otherwise, a tangent vector at x is
 % picked at random.)
@@ -20,15 +20,15 @@ function checkinverseretraction(M, x, v)
 % Change log: 
 
     if ~isfield(M, 'exp')
-        error(['This manifold has no exponential (M.exp) ' ...
-               'which is required to generate points of certain distance to x.']);
+        error(['This manifold has no exponential (M.exp) which is ' ...
+               'required to generate points at a certain distance from x.']);
     end
     if ~isfield(M, 'log')
-        error(['This manifold has no logarithmic (M.exp): ' ...
+        error(['This manifold has no logarithm (M.log): ' ...
                'no reference to compare the inverse retraction.']);
     end
     if ~isfield(M, 'norm')
-        error(['This manifold has no norm (M.nrom): ' ...
+        error(['This manifold has no norm (M.norm): ' ...
                'this is required to run this check.']);
     end
 
@@ -48,16 +48,15 @@ function checkinverseretraction(M, x, v)
     for k = 1 : numel(tt)
         t = tt(k);
         y = M.exp(M, v, t);
-        ee(k) = M.norm(M.log(x, y), M.invretr(x, y));
+        diff = M.lincomb(x, 1, M.log(x, y), -1, M.invretr(x, y));
+        ee(k) = M.norm(x, diff);
     end
     
     % Plot the difference between the exponential and the retration over
     % that span of steps, in log-log scale.
     loglog(tt, ee);
     
-    % We hope to see a slope of 3, to confirm a second-order retraction. If
-    % the slope is only 2, we have a first-order retration. If the slope is
-    % less than 2, this is not a retraction.
+    % Include visual references of slope 2 and 3.
     % Slope 3
     line('xdata', [1e-12 1e0], 'ydata', [1e-30 1e6], ...
          'color', 'k', 'LineStyle', '--', ...
@@ -77,14 +76,18 @@ function checkinverseretraction(M, x, v)
     hold off;
     
     xlabel('Step size multiplier t');
-    ylabel('Distance between Log(x, y) and InvRetr(x, y) for y = Exp(x, v, t)');
-    title(sprintf('Inverse Retraction check.\nA slope of 2 is required, 3 is desired.'));
+    ylabel('Distance between M.log(x, y) and M.invretr(x, y) for y = M.exp(x, v, t)');
+    title(sprintf(['Inverse retraction check.\n' ...
+                   'A slope of 2 is required, 3 is desired.\n' ...
+                   'Also read text output in command prompt.']));
     
     fprintf('Check agreement between M.log and M.invretr. Please check the\n');
     fprintf('factory file of M to ensure M.log is a proper logarithm.\n');
     fprintf('The slope must be at least 2 to have a proper invese retraction.\n');
     fprintf('For the inverse retraction to be second order, the slope should be 3.\n');
     fprintf('It appears the slope is: %g.\n', poly(1));
-    fprintf('Note: if exp and retr are identical, this is about zero: %g.\n', norm(ee));
-    fprintf('In the latter case, the slope test is irrelevant.\n');
+    fprintf(['Note: If M.log and M.invretr are identical, ' ...
+             'the following is about zero: %g.\n'], norm(ee));
+    fprintf(['      If so, the inverse retraction is fine and ' ...
+             'the slope test is irrelevant.\n']);
 end


### PR DESCRIPTION
I recently adapted the nice `checkretraction` for Manopt.jl, cf. https://juliamanifolds.github.io/ManifoldsBase.jl/stable/numerical_verification/#ManifoldsBase.check_retraction, and noticed, that with a slight adaption one could also check inverse retractions, cf. https://juliamanifolds.github.io/ManifoldsBase.jl/stable/numerical_verification/#ManifoldsBase.check_inverse_retraction.
I hope I adapted the check correctly. Is there some tests I would add?

A disadvantage might be, that not only log but also exp is required here.

If this is useful, I could do the same adaption and provide a `checkvectortransport` function that does something similar with parallel transport and a vector transport given a second tangent vector `w`; which has the same disadvantage of requiring exp as well (cf. https://juliamanifolds.github.io/ManifoldsBase.jl/stable/numerical_verification/#ManifoldsBase.check_vector_transport)